### PR TITLE
Split dhwebapi.py to library part and executable script

### DIFF
--- a/dhwebapi/dhwebapi.py
+++ b/dhwebapi/dhwebapi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Python library for easy communication with hub.docker.com
 
 It uses undocumented API which is primarily used by hub.docker.com frontend
@@ -244,7 +243,3 @@ def _main():
         arg_parser.print_help()
 
     return 0
-
-if __name__ == "__main__":
-    import sys
-    sys.exit(_main())

--- a/dhwebapi_cli
+++ b/dhwebapi_cli
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from dhwebapi.dhwebapi import _main as run_dhwebapi
+import sys
+
+if __name__ == "__main__":
+    sys.exit(run_dhwebapi())

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url="https://github.com/ficap/dhwebapi",
     license="MIT",
     entry_points={
-        'console_scripts': ["dhwebapi=dhwebapi.dhwebapi:_main"]
+        'console_scripts': ["dhwebapi_cli = dhwebapi.dhwebapi:_main"]
     },
     packages=["dhwebapi"],
     install_requires=["requests"]


### PR DESCRIPTION
Hello.

This PR introduces splitting the dhwebapi.py file to the library part and the executable script.

Would it be legit (or would it make sense to you) to split it like this or similarly, or rather not?
I would happily adjust the PR, if it is only partly correct.